### PR TITLE
Correctly overflow mouse scroll data on windows

### DIFF
--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -228,16 +228,17 @@ fn system_toggle(button: Button, down: bool) {
 fn system_scroll(direction: ScrollDirection, clicks: u32) {
     use winapi::um::winuser::{mouse_event, MOUSEEVENTF_WHEEL, WHEEL_DELTA};
     unsafe {
-        let multiplier: DWORD = if direction == ScrollDirection::Up {
-            1
+        let distance: DWORD = WHEEL_DELTA as DWORD * clicks as DWORD;
+        let units: DWORD = if direction == ScrollDirection::Up {
+            distance
         } else {
-            -1
+            std::u32::MAX - (distance - 1)
         };
         mouse_event(
             MOUSEEVENTF_WHEEL,
             0,
             0,
-            WHEEL_DELTA as DWORD * clicks as DWORD * multiplier,
+            units,
             0,
         );
     };


### PR DESCRIPTION
Although the `DWORD` type is commonly used as a `u32` and is aliased as such in the `winapi` crate, the `mouse_event` method can interpret it as signed.

Fixes #9 