### PR TITLE
Update image crate to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
 ]
 
 [dependencies]
-image = "0.19"
+image = "0.20"
 libc = "0.2.40"
 rand = "0.4.2"
 scopeguard = "0.3.3"

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -5,7 +5,7 @@
 extern crate image;
 
 use geometry::{Point, Rect, Size};
-use image::{DynamicImage, GenericImage, ImageError, ImageResult, Pixel, Rgba};
+use image::{DynamicImage, GenericImage, GenericImageView, ImageError, ImageResult, Pixel, Rgba};
 use screen;
 use std;
 
@@ -638,7 +638,7 @@ fn macos_load_cgimage(image: CGImage) -> ImageResult<Bitmap> {
 mod tests {
     use bitmap::{capture_screen, capture_screen_portion, colors_match, Bitmap};
     use geometry::{Point, Rect, Size};
-    use image::GenericImage;
+    use image::{GenericImage, GenericImageView};
     use image::{DynamicImage, Rgba, RgbaImage};
     use quickcheck::{Arbitrary, Gen, TestResult};
     use rand::{thread_rng, Rng};

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,6 +1,6 @@
 //! This module contains functions for working with the screen.
 extern crate image;
-use self::image::{GenericImage, ImageResult, Rgba};
+use self::image::{GenericImageView, ImageResult, Rgba};
 use bitmap;
 use geometry::{Point, Rect, Size};
 


### PR DESCRIPTION
This PR update crate `image` to its last version.

The update was pretty trivial, few methods were moved to trait GenericImageView.
Let me know if there is anything else to check.