### PR TITLE
README: fix example to compile with rand 0.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const TWO_PI: f64 = std::f64::consts::PI * 2.0;
 fn sine_mouse_wave() {
     let screen_size = autopilot::screen::size();
     let scoped_height = screen_size.height / 2.0 - 10.0; // Stay in screen bounds.
-    let rng = rand::thread_rng();
+    let mut rng = rand::thread_rng();
     for x in 0..screen_size.width as u64 {
         let y = (scoped_height * ((TWO_PI * x as f64) / screen_size.width).sin() + 
                  scoped_height).round();


### PR DESCRIPTION
this `mut` is needed to compile this example on with Rust 2018 and rand 0.6.x; not sure if it wasn't needed in a previous version of rnand or the example was always broken, but whatever the case is, it will compile after this change