### PR TITLE
Change Meta key to Super

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -511,7 +511,7 @@ impl From<Flag> for XKeyCode {
             Flag::Shift => x11::keysym::XK_Shift_L,
             Flag::Control => x11::keysym::XK_Control_L,
             Flag::Alt => x11::keysym::XK_Alt_L,
-            Flag::Meta => x11::keysym::XK_Meta_L,
+            Flag::Meta => x11::keysym::XK_Super_L,
             Flag::Help => x11::keysym::XK_Help,
         };
         XKeyCode::from(x_code)
@@ -560,7 +560,7 @@ impl From<KeyCode> for XKeyCode {
             KeyCode::Home => x11::keysym::XK_Home,
             KeyCode::Escape => x11::keysym::XK_Escape,
             KeyCode::Backspace => x11::keysym::XK_Delete,
-            KeyCode::Meta => x11::keysym::XK_Meta_L,
+            KeyCode::Meta => x11::keysym::XK_Super_L,
             KeyCode::CapsLock => x11::keysym::XK_Caps_Lock,
             KeyCode::Shift => x11::keysym::XK_Shift_L,
             KeyCode::Tab => x11::keysym::XK_Tab,


### PR DESCRIPTION
For Linux, the modification makes it possible to simulate the pressing of the "Windows" key which is Super when simulating the pressing of the key ``key.Code.META``. Indeed, knowing that the key has been associated on Windows to the "Windows" key (``winuser::VK_LWIN``) and on Mac OS to the "Apple" key (``event::KeyCode::COMMAND``), it seems more coherent to point to the **Super** key on Linux (key code X11 ``XK_Super_L```).
In any case, it would probably have been better to call this key "Super" and not "Meta" in the code, even if it means creating support for the "Meta" key separately (which is a very rare key, only existing on Sun computer keyboards according to Wikipedia).