### PR TITLE
Fix target os detection for crosscompilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,8 @@
 extern crate pkg_config;
 
-#[cfg(target_os = "macos")]
-fn main() {}
-
-#[cfg(target_os = "windows")]
-fn main() {}
-
-#[cfg(target_os = "linux")]
 fn main() {
-    println!("cargo:rustc-flags=-l X11 -l Xtst");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "linux" {
+        println!("cargo:rustc-flags=-l X11 -l Xtst");
+    }
 }


### PR DESCRIPTION
_cfg_ attribute provides _target_os_ for build.rs itself, not for the main project.
For example, if we are crosscompiling from linux to windows it will print "cargo:rustc-flags=-l X11 -l Xtst" and fail with message 'cannot find -lX11'.