### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -246,13 +246,13 @@ fn system_toggle(button: Button, down: bool) {
 #[cfg(windows)]
 fn system_scroll(direction: ScrollDirection, clicks: u32) {
     use winapi::um::winuser::{mouse_event, MOUSEEVENTF_WHEEL, WHEEL_DELTA};
+    let distance: DWORD = WHEEL_DELTA as DWORD * clicks as DWORD;
+    let units: DWORD = if direction == ScrollDirection::Up {
+        distance
+    } else {
+        std::u32::MAX - (distance - 1)
+    };
     unsafe {
-        let distance: DWORD = WHEEL_DELTA as DWORD * clicks as DWORD;
-        let units: DWORD = if direction == ScrollDirection::Up {
-            distance
-        } else {
-            std::u32::MAX - (distance - 1)
-        };
         mouse_event(MOUSEEVENTF_WHEEL, 0, 0, units, 0);
     };
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 1 function are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the mouse_event() function(unsafe function)

@msanders 
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 