### PR TITLE
Support pkg-config To Find System Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,11 @@ scopeguard = "1.1"
 quickcheck = "0.9"
 
 [build-dependencies]
-pkg-config = "0.3"
+system-deps = "2.0"
+
+[package.metadata.system-deps]
+x11 = "1"
+xtst = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ homepage = "https://www.autopy.org"
 readme = "README.md"
 repository = "https://github.com/autopilot-rs/autopilot-rs"
 license = "MIT OR Apache-2.0"
-keywords = ["cross-platform", "gui" ,"automation", "input", "simulation"]
+keywords = ["cross-platform", "gui", "automation", "input", "simulation"]
 categories = [
     "api-bindings",
     "gui",
     "os::macos-apis",
     "os::unix-apis",
-    "os::windows-apis"
+    "os::windows-apis",
 ]
 
 [dependencies]
@@ -25,12 +25,8 @@ scopeguard = "1.1"
 [dev-dependencies]
 quickcheck = "0.9"
 
-[build-dependencies]
-system-deps = "2.0"
-
-[package.metadata.system-deps]
-x11 = "1"
-xtst = "1"
+[target.'cfg(target_os = "linux")'.build-dependencies]
+pkg-config = "0.3.32"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.7.0"
@@ -41,4 +37,9 @@ cocoa = "0.20.0"
 x11 = "2.18.1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.4", features = ["libloaderapi", "minwindef", "winbase", "winuser"] }
+winapi = { version = "0.3.4", features = [
+    "libloaderapi",
+    "minwindef",
+    "winbase",
+    "winuser",
+] }

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
 fn main() {
-    system_deps::Config::new().probe().unwrap();
+    #[cfg(target_os = "linux")]
+    {
+        pkg_config::Config::new().atleast_version("1").probe("x11").unwrap();
+        pkg_config::Config::new().atleast_version("1").probe("xtst").unwrap();
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,3 @@
-extern crate pkg_config;
-
 fn main() {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
-    if target_os == "linux" {
-        println!("cargo:rustc-flags=-l X11 -l Xtst");
-    }
+    system_deps::Config::new().probe().unwrap();
 }


### PR DESCRIPTION
It appears that, while pkg-config was added as a build dependency, it wasn't actually used to find the system libraries in the `build.rs`. This PR uses `system-deps` instead, which uses `pkg-config` under the hood, but makes it slightly easier to specify the system deps in the `Cargo.toml`.

Tested locally with a non-system installation of `xau` and `xtst` successfully. Previously it was impossible to build because of missing library search paths.